### PR TITLE
Fix worker script injection bug

### DIFF
--- a/src/game/worker-final.js
+++ b/src/game/worker-final.js
@@ -16,11 +16,9 @@ async function handleRequest(request) {
     // Build the HTML with CSS injected
     let html = htmlTemplate.replace('{{CSS_CONTENT}}', cssContent);
     
-    // Inject the game bundle
+    // Inject the game bundle before the closing body tag
     const gameScript = `<script>${gameBundle}</script>`;
-    
-    // Replace the script section in the HTML
-    html = html.replace(/<script>[\s\S]*?<\/script>/, gameScript);
+    html = html.replace('</body>', `${gameScript}</body>`);
 
     return new Response(html, {
       headers: {


### PR DESCRIPTION
## Summary
- ensure the built worker keeps the game init code

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843286840088320829e6fd84040039b