### PR TITLE
Guard gradient creation against invalid coordinates

### DIFF
--- a/src/game/entities/Ingredient.js
+++ b/src/game/entities/Ingredient.js
@@ -241,7 +241,13 @@ export class Ingredient {
         for (let i = 0; i < this.trail.length - 1; i++) {
             const point = this.trail[i];
             const nextPoint = this.trail[i + 1];
-            
+
+            // Skip if coordinates are not finite to avoid rendering errors
+            if (!Number.isFinite(point.x) || !Number.isFinite(point.y) ||
+                !Number.isFinite(nextPoint.x) || !Number.isFinite(nextPoint.y)) {
+                continue;
+            }
+
             // Draw line segment with gradient
             const gradient = ctx.createLinearGradient(
                 point.x, point.y, nextPoint.x, nextPoint.y


### PR DESCRIPTION
## Summary
- skip drawing trail segments when coordinates are non-finite to avoid runtime error

## Testing
- `npm test` *(fails: vitest tests report multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_684380f0ed7483208dcf059f94db5906