### PR TITLE
Fix missing power-up helper

### DIFF
--- a/src/game/entities/PowerUp.js
+++ b/src/game/entities/PowerUp.js
@@ -215,6 +215,14 @@ export class PowerUp {
         const randomType = types[Math.floor(Math.random() * types.length)];
         return new PowerUp(randomType, options);
     }
+
+    /**
+     * Get the raw power-up type configuration map
+     * @returns {Object} mapping of power-up types to their config
+     */
+    static getPowerUpTypes() {
+        return powerUpTypes;
+    }
     
     /**
      * Get all available power-up types


### PR DESCRIPTION
## Summary
- add `PowerUp.getPowerUpTypes` static method

## Testing
- `npm test` *(fails: vitest tests currently failing)*

------
https://chatgpt.com/codex/tasks/task_e_684448dd695883208257699ef9c6ab83