### PR TITLE
Fix audio context start error

### DIFF
--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -824,10 +824,7 @@ export default class Game {
         this.frameCount = 0;
         this.lastSpawn = 0;
         this.lastPowerUpSpawn = 0;
-        
-        // Start background music
-        this.audioSystem.startBackgroundMusic();
-        
+
         // Set game state
         this.state.gameState = 'playing';
         

--- a/src/game/systems/Audio.js
+++ b/src/game/systems/Audio.js
@@ -171,11 +171,19 @@ export class AudioSystem {
      */
     setupUserInteractionHandlers() {
         const resumeAudio = () => {
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-                this.audioContext.resume();
+            if (!this.audioContext) return;
+
+            if (this.audioContext.state === 'suspended') {
+                this.audioContext.resume().then(() => {
+                    if (this.settings.music > 0 && !this.backgroundMusic.playing) {
+                        this.startBackgroundMusic();
+                    }
+                });
+            } else if (this.settings.music > 0 && !this.backgroundMusic.playing) {
+                this.startBackgroundMusic();
             }
         };
-        
+
         document.addEventListener('click', resumeAudio, { once: true });
         document.addEventListener('touchstart', resumeAudio, { once: true });
     }
@@ -340,7 +348,13 @@ export class AudioSystem {
      * Start background music
      */
     startBackgroundMusic() {
-        if (!this.audioContext || !this.enabled || this.backgroundMusic.playing || this.settings.music === 0) {
+        if (
+            !this.audioContext ||
+            !this.enabled ||
+            this.backgroundMusic.playing ||
+            this.settings.music === 0 ||
+            this.audioContext.state === 'suspended'
+        ) {
             return;
         }
         


### PR DESCRIPTION
## Summary
- only start background music after the first user interaction
- prevent attempts to start music while the audio context is suspended
- remove automatic background music start from the game initialization

## Testing
- `npm test --silent 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6844fd7095d08320a0b807ceb6ef5c08