### PR TITLE
fix: enable auto-start for game initialization

### DIFF
--- a/src/game/worker-template.js
+++ b/src/game/worker-template.js
@@ -54,8 +54,8 @@ export default {
                     showPerformanceUI: false
                 });
                 
-                // Don't start immediately - wait for user interaction
-                // game.start();
+                // Start the game immediately
+                game.start();
                 
                 // Setup UI event handlers
                 const audioToggle = document.getElementById('audioToggle');

--- a/src/worker.js
+++ b/src/worker.js
@@ -6840,8 +6840,8 @@ var Game = (function () {
                     showPerformanceUI: false
                 });
                 
-                // Don't start immediately - wait for user interaction
-                // game.start();
+                // Start the game immediately
+                game.start();
                 
                 // Setup UI event handlers
                 const audioToggle = document.getElementById('audioToggle');


### PR DESCRIPTION
- Uncommented game.start() to make game begin immediately on page load
- Removes dependency on non-existent start button
- Game now starts as soon as it's initialized

🤖 Generated with [Claude Code](https://claude.ai/code)