### PR TITLE
fix: correct game timing and ingredient spawning issues

### DIFF
--- a/src/build/game.js
+++ b/src/build/game.js
@@ -1695,7 +1695,7 @@ var Game = (function () {
             }
             
             if (shouldDecrementTime && !this.completed) {
-                this.timeLeft -= deltaTime * 1000; // Convert to milliseconds
+                this.timeLeft -= deltaTime; // deltaTime is already in milliseconds
             }
             
             if (this.timeLeft <= 0 && !this.completed) {
@@ -6021,6 +6021,16 @@ var Game = (function () {
                     possibleTypes.add(randomType);
                 }
             });
+            
+            // If no orders, spawn random ingredients to keep game active
+            if (possibleTypes.size === 0) {
+                const ingredientTypes = Ingredient.getAvailableTypes();
+                // Add 2-3 random ingredient types
+                for (let i = 0; i < Math.floor(Math.random() * 2) + 2; i++) {
+                    const randomType = ingredientTypes[Math.floor(Math.random() * ingredientTypes.length)];
+                    possibleTypes.add(randomType);
+                }
+            }
             
             if (possibleTypes.size > 0) {
                 const typesArray = Array.from(possibleTypes);

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -476,6 +476,16 @@ export default class Game {
             }
         });
         
+        // If no orders, spawn random ingredients to keep game active
+        if (possibleTypes.size === 0) {
+            const ingredientTypes = Ingredient.getAvailableTypes();
+            // Add 2-3 random ingredient types
+            for (let i = 0; i < Math.floor(Math.random() * 2) + 2; i++) {
+                const randomType = ingredientTypes[Math.floor(Math.random() * ingredientTypes.length)];
+                possibleTypes.add(randomType);
+            }
+        }
+        
         if (possibleTypes.size > 0) {
             const typesArray = Array.from(possibleTypes);
             const type = typesArray[Math.floor(Math.random() * typesArray.length)];

--- a/src/game/entities/Order.js
+++ b/src/game/entities/Order.js
@@ -67,7 +67,7 @@ export class Order {
         }
         
         if (shouldDecrementTime && !this.completed) {
-            this.timeLeft -= deltaTime * 1000; // Convert to milliseconds
+            this.timeLeft -= deltaTime; // deltaTime is already in milliseconds
         }
         
         if (this.timeLeft <= 0 && !this.completed) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -2014,7 +2014,7 @@ var Game = (function () {
             }
             
             if (shouldDecrementTime && !this.completed) {
-                this.timeLeft -= deltaTime * 1000; // Convert to milliseconds
+                this.timeLeft -= deltaTime; // deltaTime is already in milliseconds
             }
             
             if (this.timeLeft <= 0 && !this.completed) {
@@ -6340,6 +6340,16 @@ var Game = (function () {
                     possibleTypes.add(randomType);
                 }
             });
+            
+            // If no orders, spawn random ingredients to keep game active
+            if (possibleTypes.size === 0) {
+                const ingredientTypes = Ingredient.getAvailableTypes();
+                // Add 2-3 random ingredient types
+                for (let i = 0; i < Math.floor(Math.random() * 2) + 2; i++) {
+                    const randomType = ingredientTypes[Math.floor(Math.random() * ingredientTypes.length)];
+                    possibleTypes.add(randomType);
+                }
+            }
             
             if (possibleTypes.size > 0) {
                 const typesArray = Array.from(possibleTypes);


### PR DESCRIPTION
- Fixed Order deltaTime calculation (was 1000x too fast)
- Added fallback ingredient spawning when no orders exist
- Orders now expire at correct rate (30 seconds instead of 0.03 seconds)
- Ingredients now spawn even without active orders

This fixes the core gameplay loop making the game playable again.

🤖 Generated with [Claude Code](https://claude.ai/code)