### PR TITLE
Fix deltaTime comment

### DIFF
--- a/src/game/entities/Order.js
+++ b/src/game/entities/Order.js
@@ -53,7 +53,7 @@ export class Order {
 
     /**
      * Update order state
-     * @param {number} deltaTime - Time elapsed since last frame in seconds
+     * @param {number} deltaTime - Time elapsed since last frame in milliseconds
      * @param {object} gameState - Game state for power-up checks
      * @returns {boolean} True if order is still valid, false if expired
      */


### PR DESCRIPTION
## Summary
- clarify that `deltaTime` is measured in milliseconds in `Order.js`

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm install` *(fails: puppeteer download error)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd2e44d88320a71a6a3a589e92e0