### PR TITLE
Update ingredient update timing

### DIFF
--- a/src/build/game.iife.js
+++ b/src/build/game.iife.js
@@ -1303,7 +1303,8 @@ var Game = (function () {
          * @param {object} gameState - Game state for power-up checks
          * @param {number} deltaTime - Time elapsed since last frame
          */
-        update(frameCount, gameState, deltaTime = 1/60) {
+        update(frameCount, gameState, deltaTime = 16.67) {
+            // deltaTime is in ms
             this.animationTime += deltaTime;
             
             // Apply speed boost power-up if available
@@ -6051,7 +6052,7 @@ var Game = (function () {
             // Update ingredients
             for (let i = this.ingredients.length - 1; i >= 0; i--) {
                 const ingredient = this.ingredients[i];
-                ingredient.update(this.frameCount, this.state.activePowerUps);
+                ingredient.update(this.frameCount, this.state.activePowerUps, deltaTime);
                 
                 // Remove if off screen
                 if (ingredient.y > this.canvas.height + 50) {

--- a/src/build/game.js
+++ b/src/build/game.js
@@ -1323,7 +1323,8 @@ var Game = (function () {
          * @param {object} gameState - Game state for power-up checks
          * @param {number} deltaTime - Time elapsed since last frame
          */
-        update(frameCount, gameState, deltaTime = 1/60) {
+        update(frameCount, gameState, deltaTime = 16.67) {
+            // deltaTime is in ms
             this.animationTime += deltaTime;
             
             // Apply speed boost power-up if available
@@ -6108,7 +6109,7 @@ var Game = (function () {
             // Update ingredients
             for (let i = this.ingredients.length - 1; i >= 0; i--) {
                 const ingredient = this.ingredients[i];
-                ingredient.update(this.frameCount, this.state.activePowerUps);
+                ingredient.update(this.frameCount, this.state.activePowerUps, deltaTime);
                 
                 // Remove if off screen
                 if (ingredient.y > this.canvas.height + 50) {

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -562,7 +562,8 @@ export default class Game {
         // Update ingredients
         for (let i = this.ingredients.length - 1; i >= 0; i--) {
             const ingredient = this.ingredients[i];
-            ingredient.update(this.frameCount, this.state.activePowerUps);
+            // Pass deltaTime so ingredient physics stay consistent
+            ingredient.update(this.frameCount, this.state.activePowerUps, deltaTime);
             
             // Remove if off screen
             if (ingredient.y > this.canvas.height + 50) {

--- a/src/game/entities/Ingredient.js
+++ b/src/game/entities/Ingredient.js
@@ -147,7 +147,8 @@ export class Ingredient {
      * @param {object} gameState - Game state for power-up checks
      * @param {number} deltaTime - Time elapsed since last frame
      */
-    update(frameCount, gameState, deltaTime = 1/60) {
+    // deltaTime is expected in milliseconds; default assumes ~60fps
+    update(frameCount, gameState, deltaTime = 16.67) {
         this.animationTime += deltaTime;
         
         // Apply speed boost power-up if available

--- a/src/worker.js
+++ b/src/worker.js
@@ -1648,7 +1648,8 @@ var Game = (function () {
          * @param {object} gameState - Game state for power-up checks
          * @param {number} deltaTime - Time elapsed since last frame
          */
-        update(frameCount, gameState, deltaTime = 1/60) {
+        update(frameCount, gameState, deltaTime = 16.67) {
+            // deltaTime is in ms
             this.animationTime += deltaTime;
             
             // Apply speed boost power-up if available
@@ -6433,7 +6434,7 @@ var Game = (function () {
             // Update ingredients
             for (let i = this.ingredients.length - 1; i >= 0; i--) {
                 const ingredient = this.ingredients[i];
-                ingredient.update(this.frameCount, this.state.activePowerUps);
+                ingredient.update(this.frameCount, this.state.activePowerUps, deltaTime);
                 
                 // Remove if off screen
                 if (ingredient.y > this.canvas.height + 50) {

--- a/tests/entities.test.js
+++ b/tests/entities.test.js
@@ -199,7 +199,7 @@ describe('Entity Classes', () => {
       const ingredient = new Ingredient('cheese', { y: 100 })
       const initialY = ingredient.y
       
-      ingredient.update(60, null) // Frame 60, no game state
+      ingredient.update(60, null, 16.67) // Frame 60, no game state (deltaTime in ms)
       
       expect(ingredient.y).toBeGreaterThan(initialY)
     })
@@ -257,10 +257,27 @@ describe('Entity Classes', () => {
       
       // Update several times to build trail
       for (let i = 0; i < 5; i++) {
-        ingredient.update(i)
+        ingredient.update(i, undefined, 16.67)
       }
       
       expect(ingredient.trail.length).toBeGreaterThan(0)
+    })
+
+    it('should fall consistently regardless of deltaTime', () => {
+      const a = new Ingredient('cheese', { y: 0, baseSpeed: 4 })
+      const b = new Ingredient('cheese', { y: 0, baseSpeed: 4 })
+
+      // Simulate 60fps for 1 second
+      for (let i = 0; i < 60; i++) {
+        a.update(i, null, 16.67)
+      }
+
+      // Simulate 30fps for the same total time
+      for (let i = 0; i < 30; i++) {
+        b.update(i * 2, null, 33.33)
+      }
+
+      expect(Math.abs(a.y - b.y)).toBeLessThan(1)
     })
   })
 


### PR DESCRIPTION
## Summary
- pass deltaTime from `Game.update` into `Ingredient.update`
- clarify deltaTime units in `Ingredient.update` and use 16.67ms default
- propagate change to built files and worker
- adjust entity tests for new argument
- add test confirming consistent fall speed across frame rates

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd2c3b388320a866076c187efc6c