### PR TITLE
Add start screen overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,20 @@ body {
     transform: scale(0.95);
 }
 
+#startScreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    backdrop-filter: blur(5px);
+}
+
 .game-over-overlay {
     position: fixed;
     top: 0;
@@ -302,6 +316,10 @@ body {
         <canvas id="gameCanvas"></canvas>
     </div>
 
+    <div id="startScreen">
+        <button class="play-again-btn" id="startButton">Start Game</button>
+    </div>
+
     <div class="game-over-overlay" id="gameOver">
         <div class="game-over-content">
             <h1 class="game-over-title">Game Over! 🍔</h1>
@@ -321,8 +339,19 @@ body {
                     enablePerformanceMonitoring: false,
                     showPerformanceUI: false
                 });
-                game.start();
-                
+
+                const startButton = document.getElementById('startButton');
+                const startScreen = document.getElementById('startScreen');
+
+                if (startButton) {
+                    startButton.addEventListener('click', () => {
+                        if (startScreen) {
+                            startScreen.style.display = 'none';
+                        }
+                        game.start();
+                    });
+                }
+
                 // Setup UI event handlers
                 const audioToggle = document.getElementById('audioToggle');
                 const playAgainBtn = document.getElementById('playAgainBtn');

--- a/src/game/templates/styles.css
+++ b/src/game/templates/styles.css
@@ -103,6 +103,20 @@ body {
     transform: scale(0.95);
 }
 
+#startScreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    backdrop-filter: blur(5px);
+}
+
 .game-over-overlay {
     position: fixed;
     top: 0;

--- a/src/game/worker-template.js
+++ b/src/game/worker-template.js
@@ -34,6 +34,10 @@ export default {
         <canvas id="gameCanvas"></canvas>
     </div>
 
+    <div id="startScreen">
+        <button class="play-again-btn" id="startButton">Start Game</button>
+    </div>
+
     <div class="game-over-overlay" id="gameOverOverlay">
         <div class="game-over-content">
             <h1 class="game-over-title">Game Over! 🍔</h1>
@@ -54,9 +58,6 @@ export default {
                     enablePerformanceMonitoring: false,
                     showPerformanceUI: false
                 });
-                
-                // Start the game immediately
-                game.start();
                 
                 // Setup UI event handlers
                 const audioToggle = document.getElementById('audioToggle');


### PR DESCRIPTION
## Summary
- add start screen overlay and button
- start game when button pressed instead of auto-start
- mirror the overlay in Cloudflare worker template

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd267fd8832092a9407c7b63a85f