### PR TITLE
Add canvas mock in input-example tests

### DIFF
--- a/tests/input-example.test.js
+++ b/tests/input-example.test.js
@@ -25,7 +25,7 @@ describe('InputExample - setupGameInput', () => {
   beforeEach(() => {
     // Reset mocks
     vi.clearAllMocks()
-    
+
     // Create mock canvas
     canvas = {
       width: 800,
@@ -54,6 +54,9 @@ describe('InputExample - setupGameInput', () => {
       resetCombo: vi.fn(),
       addScore: vi.fn()
     }
+
+    // Attach canvas to game state for helper functions
+    gameState.canvas = canvas
   })
   
   describe('Setup', () => {


### PR DESCRIPTION
## Summary
- include canvas element on mocked game state in `input-example.test.js`

## Testing
- `npm run test:run` *(fails: expected failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7f524f88320b6bf196ae7c19ce3