### PR TITLE
Update worker test import

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,29 +1,38 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let fetchHandler
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  global.addEventListener = vi.fn((event, handler) => {
+    if (event === 'fetch') {
+      fetchHandler = handler
+    }
+  })
+})
 
 describe('Cloudflare Worker', () => {
   it('should handle fetch events', async () => {
-    // Mock the worker environment
-    global.addEventListener = vi.fn()
-    
-    // Import the worker script
-    await import('../src/worker.js')
-    
-    // Verify addEventListener was called
+    await import('../src/game/worker-entry.js')
+
     expect(global.addEventListener).toHaveBeenCalledWith('fetch', expect.any(Function))
   })
 
   it('should serve HTML for root path', async () => {
-    // Import handleRequest function (need to expose it for testing)
-    const { handleRequest } = await import('../src/worker.js').catch(() => {
-      // If not exported, we'll test via fetch event
-      return {}
-    })
-    
-    if (handleRequest) {
-      const request = new Request('https://example.com/')
-      const response = await handleRequest(request)
-      
-      expect(response.headers.get('content-type')).toBe('text/html')
+    await import('../src/game/worker-entry.js')
+
+    const mockEvent = {
+      request: new Request('https://example.com/'),
+      respondWith: vi.fn()
     }
+
+    let responsePromise
+    mockEvent.respondWith.mockImplementation(p => { responsePromise = p })
+
+    fetchHandler(mockEvent)
+    const response = await responsePromise
+
+    expect(response.headers.get('content-type')).toBe('text/html;charset=UTF-8')
   })
 })


### PR DESCRIPTION
## Summary
- update tests/worker.test.js to load `worker-entry.js`
- capture fetch event handler and check response header

## Testing
- `node node_modules/vitest/vitest.mjs run` *(fails: Cannot start service due to esbuild version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7f5710c8320b06279239a056c21