### PR TITLE
Fix canvas context for InputExample

### DIFF
--- a/src/game/systems/InputExample.js
+++ b/src/game/systems/InputExample.js
@@ -14,6 +14,12 @@ export function setupGameInput(canvas, gameState) {
         preventScroll: true,
         debug: false
     });
+
+    // Expose the canvas on the game state for helper functions
+    // that require access to its dimensions and position.
+    // Tests expect this property to be set when the input
+    // system is initialized.
+    gameState.canvas = canvas;
     
     // Register click handler for game interaction
     inputSystem.onClick((x, y, type) => {


### PR DESCRIPTION
## Summary
- ensure `setupGameInput` exposes the canvas on game state

## Testing
- `npm test` *(fails: "Tests failed" due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7f5f4d0832098d8b48c67dd10ce